### PR TITLE
自分以外の植物のCRUD処理ができないほうに修正

### DIFF
--- a/app/controllers/plants_controller.rb
+++ b/app/controllers/plants_controller.rb
@@ -1,4 +1,6 @@
 class PlantsController < ApplicationController
+  before_action :move_to_index, except: [:index, :show]
+
   def index
     @plants = Plant.all
 
@@ -7,6 +9,17 @@ class PlantsController < ApplicationController
     #binding.pry
   end
   
+  def move_to_index
+    # 自分以外のユーザーの植物の 編集/削除/新規作成はできない
+    if (user_signed_in?)    
+      if (params[:user_id].to_i != current_user.id)
+        redirect_to action: :index
+      end
+    elsif
+        redirect_to action: :index
+    end
+  end
+
   def new
     @user = User.find(params[:user_id])
     @plant = Plant.new
@@ -17,7 +30,6 @@ class PlantsController < ApplicationController
     @plant = Plant.new(plant_params)
     #binding.pry
     current_user.plants.create(plant_params)
-    #Plant.create(plant_params) 
     
   end
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -14,9 +14,13 @@
 <%= @user.email %><br>
 <h3> 所有している植物　</h3>
 <% @user.plants.each do |p| %>
-  <li><%= link_to p.plant_name ,[@user,p]%>  
-  <%= link_to "編集", [:edit, @user,p] %> 
-  <%= link_to "削除", [@user,p], method: :delete, data: {confirm: "削除しますか?"} %> </li>
+  <li><%= link_to p.plant_name ,[@user,p]%> 
+  <% if user_signed_in? %>
+    <% if current_page?(user_path(current_user.id)) %> 
+      <%= link_to "編集", [:edit, @user,p] %> 
+      <%= link_to "削除", [@user,p], method: :delete, data: {confirm: "削除しますか?"} %> </li>
+    <% end %>
+  <% end %>
 <% end %>
 <% if user_signed_in? %>
   <% if current_page?(user_path(current_user.id)) %>


### PR DESCRIPTION
#24 に対応。

ログインしているユーザーIDと現在開いているページのuser_idの相違を確認
異なっていれば植物のCRUD処理ができないようにした。
ページも編集/削除/作成を非表示にする。